### PR TITLE
Fix future aspect timing regardless of argument order

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -6055,11 +6055,14 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         if abs(v_rel) < 1e-6:
             return None
 
-        delta = (A - theta0) % 360.0
-        if v_rel < 0:
-            delta -= 360.0
+        # Compute delta for both aspect polarities (e.g. 90° and -90° for a square)
+        delta1 = (A - theta0 + 180.0) % 360.0 - 180.0
+        delta2 = (-A - theta0 + 180.0) % 360.0 - 180.0
+        delta = delta1 if abs(delta1) < abs(delta2) else delta2
 
         t = delta / v_rel
+        if t < 0:
+            t += 360.0 / abs(v_rel)
         if t <= 0 or t > max_days:
             return None
         return t

--- a/backend/tests/test_future_aspect_time.py
+++ b/backend/tests/test_future_aspect_time.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import Planet, Aspect, PlanetPosition, Sign
+
+
+def make_pos(planet, lon, speed, sign):
+    return PlanetPosition(
+        planet=planet,
+        longitude=lon,
+        latitude=0.0,
+        house=1,
+        sign=sign,
+        dignity_score=0,
+        speed=speed,
+    )
+
+
+def test_mars_jupiter_square_time_order_independent():
+    mars = make_pos(Planet.MARS, 195.97361454606846, 0.649422093300911, Sign.LIBRA)
+    jupiter = make_pos(Planet.JUPITER, 107.8889649540042, 0.17943345590025755, Sign.CANCER)
+
+    engine_cls = EnhancedTraditionalHoraryJudgmentEngine
+
+    t_mj = engine_cls._calculate_future_aspect_time(engine_cls, mars, jupiter, Aspect.SQUARE, jd_start=0.0, max_days=30)
+    t_jm = engine_cls._calculate_future_aspect_time(engine_cls, jupiter, mars, Aspect.SQUARE, jd_start=0.0, max_days=30)
+
+    assert t_mj is not None
+    assert t_jm is not None
+    assert pytest.approx(t_mj, rel=1e-2) == 4.08
+    assert pytest.approx(t_jm, rel=1e-2) == 4.08


### PR DESCRIPTION
## Summary
- ensure `_calculate_future_aspect_time` handles both aspect polarities and negative relative speeds
- add regression test confirming Mars–Jupiter square perfects in ~4.08 days regardless of argument order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b51bb9433483249f8900b80fa3a9f4