### PR TITLE
Guard translations against translator abscission

### DIFF
--- a/backend/horary_engine/perfection.py
+++ b/backend/horary_engine/perfection.py
@@ -200,6 +200,37 @@ def check_future_prohibitions(
                                             },
                                         }
                                     )
+                        # Check if the translator is cut off before completing translation
+                        translator_abscised = False
+                        for other in CLASSICAL_PLANETS:
+                            if other in (planet, sig1, sig2):
+                                continue
+                            other_pos = chart.planets.get(other)
+                            if not other_pos:
+                                continue
+                            for a2 in ASPECT_TYPES:
+                                t_trans = calc_aspect_time(p_pos, other_pos, a2, chart.julian_day, days_ahead)
+                                if _valid(t_trans, p_pos, other_pos) and t_trans < t_event:
+                                    _record_event(
+                                        {
+                                            "t": t_trans,
+                                            "payload": {
+                                                "prohibited": True,
+                                                "type": "abscission",
+                                                "abscissor": other,
+                                                "significator": planet,
+                                                "t_abscission": t_trans,
+                                                "reason": f"{other.value} cuts off light carried by {planet.value} before translation",
+                                            },
+                                        }
+                                    )
+                                    translator_abscised = True
+                                    break
+                            if translator_abscised:
+                                break
+
+                        if translator_abscised:
+                            continue
 
                         _record_event(
                             {
@@ -238,6 +269,37 @@ def check_future_prohibitions(
                         )
                         if has_reception and quality == "with difficulty":
                             reason += " (softened by reception)"
+                        translator_abscised = False
+                        for other in CLASSICAL_PLANETS:
+                            if other in (planet, sig1, sig2):
+                                continue
+                            other_pos = chart.planets.get(other)
+                            if not other_pos:
+                                continue
+                            for a2 in ASPECT_TYPES:
+                                t_trans = calc_aspect_time(p_pos, other_pos, a2, chart.julian_day, days_ahead)
+                                if _valid(t_trans, p_pos, other_pos) and t_trans < t_event:
+                                    _record_event(
+                                        {
+                                            "t": t_trans,
+                                            "payload": {
+                                                "prohibited": True,
+                                                "type": "abscission",
+                                                "abscissor": other,
+                                                "significator": planet,
+                                                "t_abscission": t_trans,
+                                                "reason": f"{other.value} cuts off light carried by {planet.value} before translation",
+                                            },
+                                        }
+                                    )
+                                    translator_abscised = True
+                                    break
+                            if translator_abscised:
+                                break
+
+                        if translator_abscised:
+                            continue
+
                         _record_event(
                             {
                                 "t": t_event,

--- a/backend/tests/test_translation.py
+++ b/backend/tests/test_translation.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from horary_engine.perfection import check_future_prohibitions
+from models import Planet, Aspect, PlanetPosition, HoraryChart, Sign
+
+
+def make_pos(planet, lon, speed, sign):
+    return PlanetPosition(
+        planet=planet,
+        longitude=lon,
+        latitude=0.0,
+        house=1,
+        sign=sign,
+        dignity_score=0,
+        speed=speed,
+    )
+
+
+def calc_aspect_time(p1, p2, aspect, jd, max_days):
+    delta = ((p1.longitude - p2.longitude - aspect.degrees + 180) % 360) - 180
+    v = p1.speed - p2.speed
+    if v == 0:
+        return None
+    return -delta / v
+
+
+def test_translation_abscission_translator_cutoff():
+    # Moon will translate Mars to Jupiter but is cut off by Sun first
+    mars = make_pos(Planet.MARS, 10.0, 0.5, Sign.ARIES)
+    jupiter = make_pos(Planet.JUPITER, 25.0, 0.2, Sign.ARIES)
+    moon = make_pos(Planet.MOON, 0.0, 13.0, Sign.ARIES)
+    sun = make_pos(Planet.SUN, 15.0, 1.0, Sign.ARIES)
+
+    planets = {p.planet: p for p in [mars, jupiter, moon, sun]}
+
+    chart = HoraryChart(
+        date_time=datetime(2024, 1, 1),
+        date_time_utc=datetime(2024, 1, 1),
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="test",
+        planets=planets,
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+    result = check_future_prohibitions(chart, Planet.MARS, Planet.JUPITER, 10.0, calc_aspect_time)
+
+    assert result["type"] == "abscission"
+    assert result["abscissor"] == Planet.SUN
+    assert result["significator"] == Planet.MOON
+    assert "cuts off light carried by Moon" in result["reason"]


### PR DESCRIPTION
## Summary
- prevent false translation when the translator perfects with another planet before delivering light
- add regression test for Moon→Mars→Jupiter showing Sun cuts off the light

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5338d41008324bf83f3ac3bccc700